### PR TITLE
Add new template for kittens in Scala 3 and update README

### DIFF
--- a/intellij-idea/README.md
+++ b/intellij-idea/README.md
@@ -6,12 +6,29 @@ e.g.)
 
 For macOS, it might be like
 ```
+"$HOME/Library/Application Support/JetBrains/YOUR_INTELLIJ_VERSION/templates"
+```
+e.g.)
+```
 "$HOME/Library/Application Support/JetBrains/IntelliJIdea2023.1/templates"
 ```
+```
+"$HOME/Library/Application Support/JetBrains/IntelliJIdea2023.2/templates"
+```
+
+***
 
 If you're using settings repository, it may look like this.
 ```
+"$HOME/Library/Application Support/JetBrains/YOUR_INTELLIJ_VERSION/settingsRepository/repository/templates"
+```
+
+e.g.)
+```
 "$HOME/Library/Application Support/JetBrains/IntelliJIdea2023.1/settingsRepository/repository/templates"
+```
+```
+"$HOME/Library/Application Support/JetBrains/IntelliJIdea2023.2/settingsRepository/repository/templates"
 ```
 
 If you don't have `templates` in your IntelliJ IDEA folder, please create it first.

--- a/intellij-idea/templates/scala3-fp.xml
+++ b/intellij-idea/templates/scala3-fp.xml
@@ -11,4 +11,11 @@
       <option name="SCALA_CODE" value="true" />
     </context>
   </template>
+  <template name="showDerivedByKittens (Scala 3)" value="given $TYPE_VAL_NAME$Show: cats.Show[$TYPE_NAME$] = cats.derived.semiauto.show$END$" description="Scala 3 - cats.derived.semiauto.show" toReformat="false" toShortenFQNames="true">
+    <variable name="TYPE_VAL_NAME" expression="" defaultValue="decapitalize(TYPE_NAME)" alwaysStopAt="false" />
+    <variable name="TYPE_NAME" expression="" defaultValue="groovyScript(&quot;return _1.findAll { c -&gt; c != '$' }.join('');&quot;, className())" alwaysStopAt="false" />
+    <context>
+      <option name="SCALA_CODE" value="true" />
+    </context>
+  </template>
 </templateSet>


### PR DESCRIPTION
Add new template for kittens in Scala 3 and update README
- Add template for `cats.derived.semiauto.show`
- Update README.md: with explicit instructions for determining the exact paths to the template folders for different IntelliJ IDEA versions and settings.